### PR TITLE
Elasticsearch Adapter #85

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "packages/adapter-memory", 
     "packages/adapter-pouchdb",
     "packages/adapter-fs",
+    "packages/adapter-elasticsearch",
     "packages/adapter-minisearch",
     "packages/adapter-hooks",
     "packages/adapter-minio",

--- a/packages/adapter-elasticsearch/adapter.js
+++ b/packages/adapter-elasticsearch/adapter.js
@@ -1,7 +1,7 @@
-import { Async } from 'crocks'
-import { pluck } from 'ramda'
+const { Async } = require('crocks')
+const { pluck } = require('ramda')
 
-export default function ({config, asyncFetch, headers, handleResponse}) {
+module.exports = function ({ config, asyncFetch, headers, handleResponse }) {
   /**
    * @typedef {Object} CreateIndexObject
    * @property {string} index

--- a/packages/adapter-elasticsearch/adapter_test.js
+++ b/packages/adapter-elasticsearch/adapter_test.js
@@ -1,8 +1,9 @@
-import { default as test } from 'tape'
-import { Async } from 'crocks'
-import { default as createAdapter } from './adapter'
-import fetchMock from 'fetch-mock'
-import { createHeaders, handleResponse } from './async-fetch'
+const test = require('tape')
+const { Async } = require('crocks')
+const fetchMock = require('fetch-mock')
+
+const createAdapter = require('./adapter')
+const { createHeaders, handleResponse } = require('./async-fetch')
 
 const headers = createHeaders('admin', 'password')
 const ES = 'http://localhost:9200'

--- a/packages/adapter-elasticsearch/adapter_test.js
+++ b/packages/adapter-elasticsearch/adapter_test.js
@@ -1,41 +1,35 @@
+
 const test = require('tape')
 const { Async } = require('crocks')
 const fetchMock = require('fetch-mock')
 
 const createAdapter = require('./adapter')
 const { createHeaders, handleResponse } = require('./async-fetch')
+const {
+  deleteIndexPath, createIndexPath, indexDocPath, getDocPath,
+  updateDocPath, removeDocPath, bulkPath, queryPath
+} = require('./paths')
 
 const headers = createHeaders('admin', 'password')
-const ES = 'http://localhost:9200'
 
-const fetch = fetchMock.sandbox()
-  .put(`${ES}/movies`, 
-    { 
-      status: 201,
-      body: { ok: true },
-      headers
-    }
-  )
-  .delete(`${ES}/movies`, {
-    status: 200,
-    body: { ok: true },
-    headers
-  })
-  .post(`${ES}/movies`, {
-    status: 201,
-    body: { ok: true },
-    headers
-  })
-  .get(`${ES}/movies/_doc/1/_source`, {
-    status: 200,
-    body: { _id: '1', hello: 'world'},
-    headers
-  })
-  .put(`${ES}/movies/_doc/1`, {
-    status: 201,
-    body: { ok: true },
-    headers
-  })
+const ES = 'http://localhost:9200'
+const INDEX = 'movies'
+
+const DOC1 = {
+  title: 'The Great Gatsby',
+  id: 'tgg',
+  year: 2012,
+  rating: 4
+}
+
+const DOC2 = {
+  title: 'The Foo Gatsby',
+  id: 'tfg',
+  year: 2012,
+  rating: 6
+}
+
+let fetch = fetchMock.sandbox()
 
 const adapter = createAdapter({
   config: { origin: ES },
@@ -44,33 +38,171 @@ const adapter = createAdapter({
   handleResponse
 })
 
+test('remove index', async t => {
+  // remove index
+  fetch.deleteOnce(deleteIndexPath(ES, INDEX), {
+    status: 200,
+    body: { ok: true },
+    headers
+  })
 
-test('create index', async t => {
-  const result = await adapter.createIndex({ index: 'movies', mapping: {}})
-  t.ok(result.ok)
+  const result = await adapter.deleteIndex(INDEX)
+
+  t.equals(result.ok, true)
   t.end()
 })
 
-test('remove index', async t => {
-  const result = await adapter.deleteIndex('movies')
-  t.ok(result.ok)
+test('create index', async t => {
+  // create index
+  fetch.putOnce(createIndexPath(ES, INDEX), 
+    { 
+      status: 201,
+      body: { ok: true },
+      headers
+    }
+  )
+
+  const result = await adapter.createIndex({
+    index: INDEX
+  })
+
+  t.equals(result.ok, true)
   t.end()
 })
 
 test('index document', async t => {
-  const result = await adapter.indexDoc({
-    index: 'movies', key: '1', doc: {hello: 'world'}
+  // index doc
+  fetch.putOnce(indexDocPath(ES, INDEX, DOC1.id), {
+    status: 200,
+    body: { ok: true },
+    headers
+  }, {
+    overwriteRoutes: true
   })
-  t.ok(result.ok)
+
+  const result = await adapter.indexDoc({
+    index: INDEX,
+    key: DOC1.id,
+    doc: DOC1
+  })
+
+  t.equals(result.ok, true)
   t.end()
 })
 
 test('get document', async t => {
+  // get doc
+  fetch.getOnce(getDocPath(ES, INDEX, DOC1.id), {
+    status: 200,
+    body: DOC1,
+    headers
+  })
+
   const result = await adapter.getDoc({
-    index: 'movies', 
-    key: '1'
+    index: INDEX, 
+    key: DOC1.id
   })
   
-  t.equal(result.doc.hello, 'world')
+  t.equals(result.doc.title, DOC1.title)
+  t.equals(result.ok, true)
+  t.end()
+})
+
+test('update document', async t => {
+  // update doc
+  fetch.putOnce(updateDocPath(ES, INDEX, DOC1.id), {
+    status: 201,
+    body: { ok: true },
+    headers
+  }, {
+    overwriteRoutes: true
+  })
+
+  const result = await adapter.updateDoc({
+    index: INDEX, 
+    key: DOC1.id,
+    doc: {
+      ...DOC1,
+      rating: 6
+    }
+  })
+  
+  t.equals(result.ok, true)
+  t.end()
+})
+
+test('delete document', async t => {
+  // remove doc
+  fetch.deleteOnce(removeDocPath(ES, INDEX, DOC1.id), {
+    status: 201,
+    body: { ok: true },
+    headers
+  })
+
+  const result = await adapter.removeDoc({
+    index: INDEX, 
+    key: DOC1.id
+  })
+  
+  t.equals(result.ok, true)
+  t.end()
+})
+
+test('bulk', async t => {
+  // bulk operation
+  fetch.postOnce(bulkPath(ES), {
+    status: 200,
+    body: {
+      items: [
+        DOC1,
+        DOC2
+      ]
+    },
+    headers
+  })
+
+  const result = await adapter.bulk({
+    index: INDEX,
+    docs: [
+      DOC1,
+      DOC2
+    ]
+  })
+  
+  t.equals(result.ok, true)
+  t.ok(result.results)
+  t.end()
+})
+
+test('query', async t => {
+  // query docs
+  fetch.postOnce(queryPath(ES, INDEX), {
+    status: 200,
+    hits: {
+      hits: [
+        DOC1,
+        DOC2
+      ]
+    }
+  })
+
+  const result = await adapter.query({
+    index: 'movies',
+    q: {
+      query: 'gatsby',
+      fields: ['title'],
+      filter: {
+        range: {
+          rating: {
+            gte: 4
+          }
+        }
+      }
+    }
+  })
+  
+  t.equals(result.ok, true)
+  t.ok(result.matches)
+  t.equals(result.matches.length, 2)
   t.end()
 })

--- a/packages/adapter-elasticsearch/async-fetch.js
+++ b/packages/adapter-elasticsearch/async-fetch.js
@@ -1,13 +1,14 @@
-import createFetch from '@vercel/fetch-retry'
-import nodeFetch from 'node-fetch'
-import { Async } from 'crocks'
-import {ifElse, propEq} from 'ramda'
-import { composeK } from 'crocks/helpers'
+const createFetch = require('@vercel/fetch-retry')
+const nodeFetch = require('node-fetch')
+const { Async } = require('crocks')
+const { composeK } = require('crocks/helpers')
+const { ifElse, propEq } = require('ramda')
 
 const fetch = createFetch(nodeFetch)
-export const asyncFetch = Async.fromPromise(fetch)
+
+const asyncFetch = Async.fromPromise(fetch)
 //export const asyncFetch = Async.fromPromise(nodeFetch)
-export const createHeaders = (username, password) => ({
+const createHeaders = (username, password) => ({
   'Content-Type': 'application/json',
   authorization: `Basic ${Buffer.from(username + ':' + password).toString('base64')}`
 })
@@ -15,7 +16,12 @@ const toJSON = (result) => Async.fromPromise(result.json.bind(result))(result);
 const toJSONReject = composeK(Async.Rejected,
   r => Async.Resolved({ok: false})
   , toJSON);
-export const handleResponse = (code) =>
+
+const handleResponse = (code) =>
   ifElse(propEq("status", code), toJSON, toJSONReject);
 
-
+module.exports = {
+  asyncFetch,
+  createHeaders,
+  handleResponse
+}

--- a/packages/adapter-elasticsearch/async-fetch.js
+++ b/packages/adapter-elasticsearch/async-fetch.js
@@ -1,24 +1,24 @@
 const createFetch = require('@vercel/fetch-retry')
 const nodeFetch = require('node-fetch')
 const { Async } = require('crocks')
-const { composeK } = require('crocks/helpers')
-const { ifElse, propEq } = require('ramda')
+const { ifElse } = require('ramda')
 
 const fetch = createFetch(nodeFetch)
 
 const asyncFetch = Async.fromPromise(fetch)
-//export const asyncFetch = Async.fromPromise(nodeFetch)
+
 const createHeaders = (username, password) => ({
   'Content-Type': 'application/json',
   authorization: `Basic ${Buffer.from(username + ':' + password).toString('base64')}`
 })
-const toJSON = (result) => Async.fromPromise(result.json.bind(result))(result);
-const toJSONReject = composeK(Async.Rejected,
-  r => Async.Resolved({ok: false})
-  , toJSON);
 
-const handleResponse = (code) =>
-  ifElse(propEq("status", code), toJSON, toJSONReject);
+const handleResponse = pred =>
+  ifElse(
+    res => pred(res),
+    res => Async.fromPromise(() => res.json())(),
+    res => Async.fromPromise(() => res.json())()
+      .chain(Async.Rejected)
+  )
 
 module.exports = {
   asyncFetch,

--- a/packages/adapter-elasticsearch/index.js
+++ b/packages/adapter-elasticsearch/index.js
@@ -1,17 +1,20 @@
-import { merge } from 'ramda'
-import adapter from './adapter'
-import { asyncFetch, createHeaders, handleResponse} from './async-fetch'
+const { mergeDeepRight, defaultTo, pipe } = require('ramda')
+const adapter = require('./adapter')
+const { asyncFetch, createHeaders, handleResponse } = require('./async-fetch')
 
-export default function (config) {
+module.exports = function ElasticsearchAdapter (config) {
   return Object.freeze({
     id: 'elasticsearch',
     port: 'search',
-    load: merge(config),
+    load: pipe(
+      defaultTo({}),
+      mergeDeepRight(config)
+    ),
     link: env => _ => {
-      if (!env.url) { throw new Error('Config URL is required elastic search')}
-      const config = new URL(env.url)
+      if (!env.url) { throw new Error('Config URL is required elastic search') }
       const headers = createHeaders(config.username, config.password)
-      return adapter({config, asyncFetch, headers, handleResponse})
+      // TODO: probably shouldn't use origin, so to support mounting elasticsearch on path
+      return adapter({ config: new URL(env.url), asyncFetch, headers, handleResponse })
     }
   })
 }

--- a/packages/adapter-elasticsearch/index_test.js
+++ b/packages/adapter-elasticsearch/index_test.js
@@ -1,6 +1,8 @@
-import { default as test } from 'tape'
-import {default as searchAdapter} from './index'
-import schema from '../../utils/plugin-schema'
+const test = require('tape')
+const searchAdapter = require('./index')
+
+// TODO: fix this broken require
+const schema = require('../../utils/plugin-schema')
 
 test('validate adapter', t => {
   t.plan(1)
@@ -11,5 +13,4 @@ test('validate adapter', t => {
     console.log(e)
     t.ok(false)
   }
-  
 })

--- a/packages/adapter-elasticsearch/index_test.js
+++ b/packages/adapter-elasticsearch/index_test.js
@@ -1,16 +1,43 @@
-const test = require('tape')
-const searchAdapter = require('./index')
 
-// TODO: fix this broken require
-const schema = require('../../utils/plugin-schema')
+const test = require('tape')
+const elasticsearchAdapterFactory = require('./index')
 
 test('validate adapter', t => {
-  t.plan(1)
-  try {
-    const result = schema(searchAdapter())
-    t.ok(true)
-  } catch (e) {
-    console.log(e)
-    t.ok(false)
+  const adapter = elasticsearchAdapterFactory({})
+  t.ok(adapter)
+  t.end()
+})
+
+test('validate load()', t => {
+  const config = { foo: 'bar' }
+  const adapter = elasticsearchAdapterFactory(config)
+
+  const loadedConfig = adapter.load({ fizz: 'buzz' })
+  t.equals(loadedConfig.foo, config.foo)
+  t.equals(loadedConfig.fizz, 'buzz')
+  t.end()
+})
+
+test('validate link()', t => {
+  const config = {
+    username: 'foo',
+    password: 'bar',
+    url: 'http://localhost:9200'
   }
+
+  const adapter = elasticsearchAdapterFactory(config)
+  t.ok(adapter.link(config)())
+  t.end()
+})
+
+test('validate link() - no url', t => {
+  const config = {
+    username: 'foo',
+    password: 'bar',
+    no_url: 'http://localhost:9200'
+  }
+
+  const adapter = elasticsearchAdapterFactory(config)
+  t.throws(() => adapter.link(config)(), 'Config URL is required elastic search')
+  t.end()
 })

--- a/packages/adapter-elasticsearch/package.json
+++ b/packages/adapter-elasticsearch/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@hyper63/adapter-elasticsearch",
+  "version": "0.0.1",
   "dependencies": {
     "@vercel/fetch-retry": "^5.0.3",
     "crocks": "^0.12.4",
-    "esm": "^3.2.25",
     "node-fetch": "^2.6.1",
     "ramda": "^0.27.1"
   },

--- a/packages/adapter-elasticsearch/package.json
+++ b/packages/adapter-elasticsearch/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@hyper63/adapter-elasticsearch",
   "version": "0.0.1",
+  "scripts": {
+    "test": "tape *_test.js"
+  },
   "dependencies": {
     "@vercel/fetch-retry": "^5.0.3",
     "crocks": "^0.12.4",

--- a/packages/adapter-elasticsearch/paths.js
+++ b/packages/adapter-elasticsearch/paths.js
@@ -1,0 +1,43 @@
+
+function createIndexPath (root, index) {
+  return `${root}/${index}`
+}
+
+function deleteIndexPath (root, index) {
+  return `${root}/${index}`
+}
+
+function indexDocPath (root, index, key) {
+  return `${root}/${index}/_doc/${key}`
+}
+
+function updateDocPath (root, index, key) {
+  return `${root}/${index}/_doc/${key}`
+}
+
+function removeDocPath (root, index, key) {
+  return `${root}/${index}/_doc/${key}`
+}
+
+function getDocPath (root, index, key) {
+  return `${root}/${index}/_doc/${key}/_source`
+}
+
+function bulkPath (root) {
+  return `${root}/_bulk`
+}
+
+function queryPath (root, index) {
+  return `${root}/${index}/_search`
+}
+
+module.exports = {
+  createIndexPath,
+  deleteIndexPath,
+  indexDocPath,
+  updateDocPath,
+  removeDocPath,
+  getDocPath,
+  bulkPath,
+  queryPath
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -232,6 +232,16 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@hyper63/adapter-couchdb@0.0.6":
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/@hyper63/adapter-couchdb/-/adapter-couchdb-0.0.6.tgz#002a46ca630bef985f3ddbd66466b18fac02a4c6"
+  integrity sha512-hrARaukIzGvUBAPuI8uDs29lT83AtJa0+6e+UqW0gST+ABsyxE7bVrYezb8s0/9fsEAeAd9Mf/2yTMb+Q2009g==
+  dependencies:
+    "@vercel/fetch" "^6.1.0"
+    crocks "^0.12.4"
+    node-fetch "^2.6.1"
+    ramda "^0.27.1"
+
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@protobufjs/aspromise/-/aspromise-1.1.2.tgz#9b8b0cc663d669a7d8f6f5d0893a14d348f30fbf"


### PR DESCRIPTION
closes #85 

First pass at an Elasticsearch adapter. I left some open questions as `TODOs` in the adapter file that we can address in later iterations of the adapter.

One thing that I went back and forth on was determining a meaningful way to use the `mappings`, as specified by the Search Port for `createIndex`. Because Elasticsearch requires `type` for each property, and that's not part of the Search Port, I felt that I couldn't do much with `mappings`. For now, I just made it such that every index created in Elasticsearch uses [dynamic mapping](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping.html#_dynamic_mapping).

Open to suggestions on all these changes. Thanks. 😃 